### PR TITLE
Don't COW the internal `this` constant

### DIFF
--- a/Assets/UdonSharp/Editor/Compiler/Emit/ValueTable.cs
+++ b/Assets/UdonSharp/Editor/Compiler/Emit/ValueTable.cs
@@ -118,7 +118,8 @@ namespace UdonSharp.Compiler.Emit
                 }
             }
 
-            return GlobalTable.CreateValueInternal(type, null, Value.ValueFlags.UdonThis);
+            return GlobalTable.CreateValueInternal(type, null, 
+                Value.ValueFlags.UdonThis | Value.ValueFlags.Constant, "this");
         }
 
         public Value GetUserValue(Symbol userSymbol)

--- a/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs.meta
+++ b/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1acffbcca59d874d972a687072fbf1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.asset
+++ b/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.asset
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: TestTernary
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: e78bf5d7d48cd7341b4eb2f0231028d4,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: e22289e14719433449457b8b61fad2f7, type: 3}
+  behaviourSyncMode: 0
+  compileErrors: []
+  hasInteractEvent: 0
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: x
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: x
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TestTernary, Assembly-CSharp
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 4|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.Udon.UdonBehaviour, VRC.Udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 5|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.asset.meta
+++ b/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99c369d71d3a56a40838db52f860f51d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.cs
+++ b/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.cs
@@ -1,0 +1,41 @@
+﻿
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.Udon;
+
+namespace UdonSharp.Tests
+{
+    /// <summary>
+    /// Incorrect COW handling across a ternary can cause intermediate values accessed after the completion of the
+    /// ternary to use uninitialized values.
+    /// </summary>
+    public class TestTernary : UdonSharpBehaviour
+    {
+        private TestTernary x;
+
+        [System.NonSerialized] public IntegrationTestSuite tester;
+
+        public void ExecuteTests()
+        {
+            enabled = true ? true : val;
+            enabled = false ? true : val;
+            tester.TestAssertion("Ternary access COWing 'this' succeeded", true);
+            
+            x = this;
+            x.enabled = true ? true : val;
+            x.enabled = false ? true : x.val;
+            tester.TestAssertion("Ternary access COWing a field succeeded", true);
+        }
+
+        private void Start()
+        {
+            enabled = true ? true : val;
+
+            x = this;
+            x.enabled = true ? true : x.val;
+        }
+
+        public bool val => true;
+    }
+}

--- a/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.cs.meta
+++ b/Assets/UdonSharp/Tests~/TestScripts/BugTests/TernaryCOWBugs/TestTernary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e22289e14719433449457b8b61fad2f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Certain ternary expressions could result in COWing the internal `this`
constant unnecessarily. Mark `this` as constant to avoid this.

Because this hides another bug, I've added a (currently failing) test that
detects the more general case of inappropriate COWing across ternary
operators. I've not added it to the scene because I'm sure the merge will
be a nightmare (and it's failing until some of Merlin's working branch
changes land)

This is a resubmission of https://github.com/MerlinVR/UdonSharp/pull/132
against the newer branch and new repo.