### PR TITLE
Handle local constants as constants

### DIFF
--- a/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundAccessExpression.cs
+++ b/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundAccessExpression.cs
@@ -33,7 +33,7 @@ namespace UdonSharp.Compiler.Binder
             switch (accessSymbol)
             {
                 case LocalSymbol localSymbol:
-                    return new BoundLocalAccessExpression(node, localSymbol);
+                    return BoundLocalAccessExpression.BindLocalAccess(node, localSymbol);
                 case ParameterSymbol parameterSymbol:
                     return new BoundParameterAccessExpression(node, parameterSymbol);
                 case FieldSymbol fieldSymbol:
@@ -85,8 +85,19 @@ namespace UdonSharp.Compiler.Binder
                 AccessSymbol = accessSymbol;
             }
 
+            public static BoundAccessExpression BindLocalAccess(SyntaxNode node, LocalSymbol localSymbol)
+            {
+                if (localSymbol.IsConst)
+                    return new BoundConstantExpression(localSymbol.ConstantValue, localSymbol.Type);
+
+                return new BoundLocalAccessExpression(node, localSymbol);
+            }
+
             public override Value EmitValue(EmitContext context)
             {
+                if (AccessSymbol.IsConst)
+                    return context.GetConstantValue(ValueType, AccessSymbol.ConstantValue);
+
                 return context.GetUserValue(AccessSymbol);
             }
 

--- a/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundVariableDeclaratorStatement.cs
+++ b/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundVariableDeclaratorStatement.cs
@@ -19,6 +19,9 @@ namespace UdonSharp.Compiler.Binder
 
         public override void Emit(EmitContext context)
         {
+            if (UserSymbol is LocalSymbol localSymbol && localSymbol.IsConst)
+                return;
+
             Value userValue = context.GetUserValue(UserSymbol);
 
             if (Initializer == null) return;

--- a/Assets/UdonSharp/Editor/Compiler/Binder/Symbols/LocalSymbol.cs
+++ b/Assets/UdonSharp/Editor/Compiler/Binder/Symbols/LocalSymbol.cs
@@ -17,7 +17,10 @@ namespace UdonSharp.Compiler.Symbols
             Type = bindContext.GetTypeSymbol(sourceSymbol.Type);
         }
 
-        public new ILocalSymbol RoslynSymbol { get { return (ILocalSymbol)base.RoslynSymbol; } }
+        public new ILocalSymbol RoslynSymbol => (ILocalSymbol)base.RoslynSymbol;
+
+        public bool IsConst => RoslynSymbol.IsConst;
+        public object ConstantValue => RoslynSymbol.ConstantValue;
 
         public override void Bind(BindContext context)
         {

--- a/Assets/UdonSharp/Tests~/TestScripts/FlowControl/SwitchTest.cs
+++ b/Assets/UdonSharp/Tests~/TestScripts/FlowControl/SwitchTest.cs
@@ -50,7 +50,7 @@ namespace UdonSharp.Tests
             
             tester.TestAssertion("Float switch 1", FloatSwitch(1) == "one");
             tester.TestAssertion("Float switch 2", FloatSwitch(2) == "two");
-            tester.TestAssertion("Float switch 1", FloatSwitch(1.2f) == "no switch val found");
+            tester.TestAssertion("Float switch 3", FloatSwitch(1.2f) == "no switch val found");
             
             tester.TestAssertion("User enum jump table switch 1", TestUserJumpTableEnumSwitch(MySwitchEnum.A) == "A");
             tester.TestAssertion("User enum jump table switch 2", TestUserJumpTableEnumSwitch(MySwitchEnum.B) == "B");
@@ -64,6 +64,10 @@ namespace UdonSharp.Tests
             tester.TestAssertion("Object switch 2", ObjectSwitch(2) == "two");
             tester.TestAssertion("Object switch 3", ObjectSwitch(2L) == "two long");
             tester.TestAssertion("Object switch 4", ObjectSwitch("testVal") == "the testVal");
+
+            tester.TestAssertion("Const variable switch 1", ConstVariableSwitch(1) == "one");
+            tester.TestAssertion("Const variable switch 2", ConstVariableSwitch(2) == "two");
+            tester.TestAssertion("Const variable switch 3", ConstVariableSwitch(3) == "no switch val found");
         }
 
         private string TestSwitch(int switchVal)
@@ -174,6 +178,22 @@ namespace UdonSharp.Tests
                 case 1:
                     return "one";
                 case 2f:
+                    return "two";
+            }
+
+            return "no switch val found";
+        }
+        
+        const int one = 1;
+        private string ConstVariableSwitch(int val)
+        {
+            const int two = 2;
+
+            switch (val)
+            {
+                case one:
+                    return "one";
+                case two:
                     return "two";
             }
 


### PR DESCRIPTION
A local constant can be the case pattern of a switch statement.
Skip creating variables for local constants.
Accessing a local constant gets the constant directly.