### PR TITLE
Fix string composite assignment

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -390,7 +390,28 @@ namespace UdonSharp.Tests
             
             s += stringChar;
             tester.TestAssertion("Char addition non const", s == "abcdef42ab");
+            
+            s += 1;
+            tester.TestAssertion("Int addition", s == "abcdef42ab1");
+
+            s = "ab";
+            s += gameObject;
+            tester.TestAssertion("Object addition", s == "ab" + gameObject.ToString());
+            
+            object o = "ab";
+            o = o + "cd";
+            o += "ef";
+            tester.TestAssertion("String Op +(object, string)", o.ToString() == "abcdef");
+
+            //s = "ab";
+            //s += this;
+            //tester.TestAssertion("USB addition", s == "abUSBString");
         }
+
+        //public override string ToString()
+        //{
+        //    return "USBString";
+        //}
         
         void BitwiseNot()
         {

--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -402,16 +402,7 @@ namespace UdonSharp.Tests
             o = o + "cd";
             o += "ef";
             tester.TestAssertion("String Op +(object, string)", o.ToString() == "abcdef");
-
-            //s = "ab";
-            //s += this;
-            //tester.TestAssertion("USB addition", s == "abUSBString");
         }
-
-        //public override string ToString()
-        //{
-        //    return "USBString";
-        //}
         
         void BitwiseNot()
         {


### PR DESCRIPTION
Fixes an issue where compound assignments containing strings cause an error at runtime.
Call string.Concat if either the left or right side is something other than string.
Convert the right side to string in advance if that is other than string and is a constant.