### PR TITLE
RequestSerialization should be virtual

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Runtime/UdonSharpBehaviour.cs
+++ b/Packages/com.vrchat.UdonSharp/Runtime/UdonSharpBehaviour.cs
@@ -145,7 +145,7 @@ namespace UdonSharp
         /// <remarks>This will only function if the UdonSharpBehaviour is set to Manual sync mode and the person calling RequestSerialization() is the owner of the object.</remarks>
         /// </summary>
         [PublicAPI]
-        public void RequestSerialization() { }
+        public virtual void RequestSerialization() { }
 
         // Stubs for builtin UdonSharp methods to get type info
         private static long GetUdonTypeID(System.Type type)


### PR DESCRIPTION
RequestSerialization is technically a
built-in, but there's no reason to 
prevent extension by developers
(or warn against it, depending on
the IDE).

An example of this usecase is
the common pattern of calling `RequestSerialization()` and then
`OnDeserialization()`. By extending
`RequestSerialization` we can declare
that we always will call 
`OnDeserialization` afterwards, reducing
boilerplate.

Other examples: if we would like
to update an atomic clock by one
whenever we call RequestSerialization,
or we might want to automate assigning
ownership.