### PR TITLE
fix: ArgumentOutOfRangeException on non-Windows

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpAssetCompileWatcher.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpAssetCompileWatcher.cs
@@ -172,7 +172,8 @@ namespace UdonSharpEditor
         {
             lock (_modifiedFileLock) // The watcher runs on a different thread, and I don't feel like using a concurrent list.
             {
-                _modifiedFilePaths.Add(args.FullPath);
+                // There's some platform args.FullPath may be a relative path.
+                _modifiedFilePaths.Add(Path.GetFullPath(args.FullPath));
             }
         }
     }


### PR DESCRIPTION
The FileSystemEventArgs.FullPath may be a relative path on some platforms like macOS.
If _modifiedFilePaths is not absolute, in OnEditorUpdate, ArgumentOutOfRangeException will be happened.