### PR TITLE
Releases/1.1.2

### DIFF
--- a/Packages/com.vrchat.UdonSharp/package.json
+++ b/Packages/com.vrchat.UdonSharp/package.json
@@ -1,7 +1,7 @@
 {
 	"name" : "com.vrchat.udonsharp",
 	"displayName" : "UdonSharp",
-	"version" : "1.1.1",
+	"version" : "1.1.2",
 	"unity" : "2019.4",
 	"description" : "A compiler for compiling C# to Udon assembly",
 	"author" : {

--- a/Tools/Docusaurus/news/releases/release-1.1.2.md
+++ b/Tools/Docusaurus/news/releases/release-1.1.2.md
@@ -1,0 +1,18 @@
+---
+slug: release-1.1.2
+title: Release 1.1.2
+date: 2022-10-24
+authors: [momo]
+tags: [release]
+draft: false
+---
+
+## Changelog
+
+- Adds logging for what is not supported when hit in early compile phases.
+- Fixes for inspector issues
+- Make U# assembly definitions reset caches
+- Create data locator after importing samples
+- Fixes issue due to Udon Networking changes
+- Adds sync type checking
+- Updates Readme with VPM Usage Instructions


### PR DESCRIPTION
## Changelog

- Adds logging for what is not supported when hit in early compile phases.
- Fixes for inspector issues
- Make U# assembly definitions reset caches
- Create data locator after importing samples
- Fixes issue due to Udon Networking changes
- Adds sync type checking
- Updates Readme with VPM Usage Instructions