### PR TITLE
Fix negative float to integer truncation

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -567,14 +567,13 @@ namespace UdonSharp.Compiler.Emit
                                 ? GetTypeSymbol(SpecialType.System_Decimal)
                                 : GetTypeSymbol(SpecialType.System_Double);
 
-                            if (!_mathTruncateMethodSymbolTable.ContainsKey(floatType.UdonType))
+                            if (!_mathTruncateMethodSymbolTable.TryGetValue(floatType.UdonType, out MethodSymbol mathTruncateMethodSymbol))
                             {
-                                _mathTruncateMethodSymbolTable.Add(floatType.UdonType,
-                                    GetTypeSymbol(typeof(Math)).GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
-                                    .First(e => e.ReturnType.UdonType == floatType.UdonType));
-                            }
+                                mathTruncateMethodSymbol = GetTypeSymbol(typeof(Math)).GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
+                                    .First(e => e.ReturnType.UdonType == floatType.UdonType);
 
-                            MethodSymbol mathTruncateMethodSymbol = _mathTruncateMethodSymbolTable[floatType.UdonType];
+                                _mathTruncateMethodSymbolTable.Add(floatType.UdonType, mathTruncateMethodSymbol);
+                            }
 
                             sourceValue = CastValue(sourceValue, floatType, true);
 

--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -570,7 +570,7 @@ namespace UdonSharp.Compiler.Emit
                             if (!_mathTruncateMethodSymbolTable.TryGetValue(floatType.UdonType, out MethodSymbol mathTruncateMethodSymbol))
                             {
                                 mathTruncateMethodSymbol = GetTypeSymbol(typeof(Math)).GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
-                                    .First(e => e.ReturnType.UdonType == floatType.UdonType);
+                                    .First(e => e.Parameters[0].Type == floatType.UdonType);
 
                                 _mathTruncateMethodSymbolTable.Add(floatType.UdonType, mathTruncateMethodSymbol);
                             }

--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -575,7 +575,7 @@ namespace UdonSharp.Compiler.Emit
                                 {
                                     _mathTruncateDecimalMethodSymbol = GetTypeSymbol(typeof(Math))
                                         .GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
-                                        .Where(x => x.ReturnType == floatType).First();
+                                        .First(e => e.ReturnType.UdonType == floatType.UdonType);
                                 }
                                 mathTruncateMethodSymbol = _mathTruncateDecimalMethodSymbol;
                             }
@@ -586,7 +586,7 @@ namespace UdonSharp.Compiler.Emit
                                 {
                                     _mathTruncateDoubleMethodSymbol = GetTypeSymbol(typeof(Math))
                                         .GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
-                                        .Where(x => x.ReturnType == floatType).First();
+                                        .First(e => e.ReturnType.UdonType == floatType.UdonType);
                                 }
                                 mathTruncateMethodSymbol = _mathTruncateDoubleMethodSymbol;
                             }

--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -469,7 +469,8 @@ namespace UdonSharp.Compiler.Emit
             return enumArrayValue;
         }
 
-        private MethodSymbol _mathfFloorMethodSymbol;
+        private MethodSymbol _mathTruncateDecimalMethodSymbol;
+        private MethodSymbol _mathTruncateDoubleMethodSymbol;
 
         private void CastValue(Value sourceValue, Value targetValue, bool explicitCast)
         {
@@ -563,14 +564,36 @@ namespace UdonSharp.Compiler.Emit
                         if (UdonSharpUtils.IsFloatType(sourceType.UdonType.SystemType) &&
                             UdonSharpUtils.IsIntegerType(targetType.UdonType.SystemType))
                         {
-                            TypeSymbol floatType = GetTypeSymbol(SpecialType.System_Single);
+                            TypeSymbol floatType;
+
+                            MethodSymbol mathTruncateMethodSymbol;
+
+                            if (sourceType.UdonType.SystemType == typeof(decimal))
+                            {
+                                floatType = GetTypeSymbol(SpecialType.System_Decimal);
+                                if (_mathTruncateDecimalMethodSymbol == null)
+                                {
+                                    _mathTruncateDecimalMethodSymbol = GetTypeSymbol(typeof(Math))
+                                        .GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
+                                        .Where(x => x.ReturnType == floatType).First();
+                                }
+                                mathTruncateMethodSymbol = _mathTruncateDecimalMethodSymbol;
+                            }
+                            else
+                            {
+                                floatType = GetTypeSymbol(SpecialType.System_Double);
+                                if (_mathTruncateDoubleMethodSymbol == null)
+                                {
+                                    _mathTruncateDoubleMethodSymbol = GetTypeSymbol(typeof(Math))
+                                        .GetMembers<MethodSymbol>(nameof(Math.Truncate), this)
+                                        .Where(x => x.ReturnType == floatType).First();
+                                }
+                                mathTruncateMethodSymbol = _mathTruncateDoubleMethodSymbol;
+                            }
+
                             sourceValue = CastValue(sourceValue, floatType, true);
 
-                            if (_mathfFloorMethodSymbol == null)
-                                _mathfFloorMethodSymbol =
-                                    GetTypeSymbol(typeof(Mathf)).GetMember<MethodSymbol>("Floor", this);
-
-                            sourceValue = EmitValue(BoundInvocationExpression.CreateBoundInvocation(this, null, _mathfFloorMethodSymbol,
+                            sourceValue = EmitValue(BoundInvocationExpression.CreateBoundInvocation(this, null, mathTruncateMethodSymbol,
                                 null,
                                 new BoundExpression[] {BoundAccessExpression.BindAccess(sourceValue)}));
                         

--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -346,9 +346,22 @@ namespace UdonSharp.Tests
             double testDouble = 4.7f;
             truncatedValue = (int)testFloat;
             tester.TestAssertion("Float to Int Truncation", truncatedValue == 4);
-        
+
             truncatedValue = (int)testDouble;
             tester.TestAssertion("Double to Int Truncation", truncatedValue == 4);
+
+            float testNegativeFloat = -4.7f;
+            double testNegativeDouble = -4.7;
+            decimal testNegativeDecimal = -4.7m;
+
+            truncatedValue = (int)testNegativeFloat;
+            tester.TestAssertion("Float to Int Truncation", truncatedValue == -4);
+
+            truncatedValue = (int)testNegativeDouble;
+            tester.TestAssertion("Double to Int Truncation", truncatedValue == -4);
+
+            truncatedValue = (int)testNegativeDecimal;
+            tester.TestAssertion("Decimal to Int Truncation", truncatedValue == -4);
         }
         
         void UintBitOps()

--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -355,13 +355,13 @@ namespace UdonSharp.Tests
             decimal testNegativeDecimal = -4.7m;
 
             truncatedValue = (int)testNegativeFloat;
-            tester.TestAssertion("Float to Int Truncation", truncatedValue == -4);
+            tester.TestAssertion("Negative Float to Int Truncation", truncatedValue == -4);
 
             truncatedValue = (int)testNegativeDouble;
-            tester.TestAssertion("Double to Int Truncation", truncatedValue == -4);
+            tester.TestAssertion("Negative Double to Int Truncation", truncatedValue == -4);
 
             truncatedValue = (int)testNegativeDecimal;
-            tester.TestAssertion("Decimal to Int Truncation", truncatedValue == -4);
+            tester.TestAssertion("Negative Decimal to Int Truncation", truncatedValue == -4);
         }
         
         void UintBitOps()


### PR DESCRIPTION
Change the method for casting floats to integers from `Mathf.Floor` to `Math.Truncate`.
Same result as C# when casting a negative floating point number to an integer.