### PR TITLE
Fix cast between `char` and Float types

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -583,7 +583,7 @@ namespace UdonSharp.Compiler.Emit
                         
                             conversionMethod = GetNumericConversionMethod(floatType, targetType);
                         }
-						else if (sourceType == GetTypeSymbol(SpecialType.System_Char) && UdonSharpUtils.IsFloatType(targetType.UdonType.SystemType) ||
+                        else if (sourceType == GetTypeSymbol(SpecialType.System_Char) && UdonSharpUtils.IsFloatType(targetType.UdonType.SystemType) ||
                             UdonSharpUtils.IsFloatType(sourceType.UdonType.SystemType) && targetType == GetTypeSymbol(SpecialType.System_Char))
                         {
                             TypeSymbol ushortType = GetTypeSymbol(SpecialType.System_UInt16);

--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Emit/EmitContext.cs
@@ -413,10 +413,17 @@ namespace UdonSharp.Compiler.Emit
             EmitReturn();
         }
 
+        Dictionary<(TypeSymbol, TypeSymbol), MethodSymbol> _numericConversionMethod = new Dictionary<(TypeSymbol, TypeSymbol), MethodSymbol>();
+
         private MethodSymbol GetNumericConversionMethod(TypeSymbol sourceType, TypeSymbol targetType)
         {
-            MethodSymbol convertMethod = GetTypeSymbol(typeof(Convert)).GetMembers<MethodSymbol>($"To{targetType.UdonType.Name}", this)
-                .FirstOrDefault(e => e.Parameters[0].Type == sourceType.UdonType);
+            if (!_numericConversionMethod.TryGetValue((sourceType.UdonType, targetType.UdonType), out MethodSymbol convertMethod))
+            {
+                convertMethod = GetTypeSymbol(typeof(Convert)).GetMembers<MethodSymbol>($"To{targetType.UdonType.Name}", this)
+                    .FirstOrDefault(e => e.Parameters[0].Type == sourceType.UdonType);
+
+                _numericConversionMethod.Add((sourceType.UdonType, targetType.UdonType), convertMethod);
+            }
 
             return convertMethod;
         }
@@ -575,6 +582,15 @@ namespace UdonSharp.Compiler.Emit
                                 new BoundExpression[] {BoundAccessExpression.BindAccess(sourceValue)}));
                         
                             conversionMethod = GetNumericConversionMethod(floatType, targetType);
+                        }
+						else if (sourceType == GetTypeSymbol(SpecialType.System_Char) && UdonSharpUtils.IsFloatType(targetType.UdonType.SystemType) ||
+                            UdonSharpUtils.IsFloatType(sourceType.UdonType.SystemType) && targetType == GetTypeSymbol(SpecialType.System_Char))
+                        {
+                            TypeSymbol ushortType = GetTypeSymbol(SpecialType.System_UInt16);
+
+                            sourceValue = CastValue(sourceValue, ushortType, true);
+
+                            conversionMethod = GetNumericConversionMethod(ushortType, targetType);
                         }
                     }
                     

--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -32,6 +32,7 @@ namespace UdonSharp.Tests
             DecimalOps();
             BitwiseNot();
             UdonBehaviourFieldCompoundAssignment();
+            CastCharToFloat();
         }
 
         void IntBinaryOps()
@@ -432,6 +433,21 @@ namespace UdonSharp.Tests
             self._testVec.x += 3;
             
             tester.TestAssertion("Field struct compound assignment", _testVec.x == 4);
+        }
+
+        void CastCharToFloat()
+        {
+            float af = 97.5f;
+            double ad = 98.5;
+            decimal am = 99.5m;
+            tester.TestAssertion("Cast float to char", (char)af == 'a');
+            tester.TestAssertion("Cast double to char", (char)ad == 'b');
+            tester.TestAssertion("Cast decimal to char", (char)am == 'c');
+
+            char c = 'a';
+            tester.TestAssertion("Cast char to float", c == 97f);
+            tester.TestAssertion("Cast char to double", c == 97.0);
+            tester.TestAssertion("Cast char to decimal", c == 97m);
         }
     }
 }


### PR DESCRIPTION
An error occurs because the Convert class does not support casting between Char and Float types.
Therefore, cast via ushort type once.