### PR TITLE
Nested prefab upgrade fixes

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpEditorManager.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpEditorManager.cs
@@ -907,7 +907,7 @@ namespace UdonSharpEditor
                 if (prefabRoot == null)
                     continue;
                 
-                var prefabAssetType = PrefabUtility.GetPrefabAssetType(prefabRoot);
+                PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(prefabRoot);
                 if (prefabAssetType == PrefabAssetType.Model || 
                     prefabAssetType == PrefabAssetType.MissingAsset)
                     continue;
@@ -919,7 +919,7 @@ namespace UdonSharpEditor
 
                 bool hasUdonSharpBehaviour = false;
 
-                foreach (var behaviour in behaviourScratch)
+                foreach (UdonBehaviour behaviour in behaviourScratch)
                 {
                     if (UdonSharpEditorUtility.IsUdonSharpBehaviour(behaviour))
                     {
@@ -942,7 +942,7 @@ namespace UdonSharpEditor
             
             HashSet<GameObject> newObjectSet = new HashSet<GameObject>();
 
-            foreach (var unityObject in unityObjects)
+            foreach (Object unityObject in unityObjects)
             {
                 if (unityObject == null)
                     continue;
@@ -953,7 +953,7 @@ namespace UdonSharpEditor
                 if (!PrefabUtility.IsPartOfPrefabAsset(unityObject))
                     continue;
 
-                var prefabAssetType = PrefabUtility.GetPrefabAssetType(unityObject);
+                PrefabAssetType prefabAssetType = PrefabUtility.GetPrefabAssetType(unityObject);
                 if (prefabAssetType == PrefabAssetType.Model || 
                     prefabAssetType == PrefabAssetType.MissingAsset)
                     continue;
@@ -995,12 +995,12 @@ namespace UdonSharpEditor
             if (behaviour == null)
                 return unityObjects;
             
-            var unityObjectList = (List<Object>)_serializedObjectReferencesField.GetValue(behaviour);
+            List<Object> unityObjectList = (List<Object>)_serializedObjectReferencesField.GetValue(behaviour);
 
             if (unityObjectList == null)
                 return unityObjects;
 
-            foreach (var unityObject in unityObjectList)
+            foreach (Object unityObject in unityObjectList)
             {
                 if (unityObject is Component || unityObject is GameObject)
                     unityObjects.Add(unityObject);
@@ -1013,7 +1013,7 @@ namespace UdonSharpEditor
         {
             HashSet<GameObject> prefabRoots = new HashSet<GameObject>();
 
-            foreach (var udonBehaviour in allBehaviours)
+            foreach (UdonBehaviour udonBehaviour in allBehaviours)
             {
                 if (!PrefabUtility.IsPartOfPrefabInstance(udonBehaviour))
                     continue;
@@ -1033,7 +1033,7 @@ namespace UdonSharpEditor
         {
             HashSet<GameObject> gameObjectsToVisit = new HashSet<GameObject>();
 
-            foreach (var rootBehaviour in rootSet)
+            foreach (UdonBehaviour rootBehaviour in rootSet)
             {
                 HashSet<Object> objects = GetBehaviourComponentOrGameObjectReferences(rootBehaviour);
                 gameObjectsToVisit.UnionWith(GetRootPrefabGameObjectRefs(objects.Count != 0 ? objects : null));
@@ -1052,14 +1052,14 @@ namespace UdonSharpEditor
             {
                 HashSet<GameObject> newVisitSet = new HashSet<GameObject>();
 
-                foreach (var gameObject in gameObjectsToVisit)
+                foreach (GameObject gameObject in gameObjectsToVisit)
                 {
                     if (visitedSet.Contains(gameObject))
                         continue;
 
                     visitedSet.Add(gameObject);
                     
-                    foreach (var udonBehaviour in gameObject.GetComponentsInChildren<UdonBehaviour>(true))
+                    foreach (UdonBehaviour udonBehaviour in gameObject.GetComponentsInChildren<UdonBehaviour>(true))
                     {
                         HashSet<Object> objectRefs;
 
@@ -1081,7 +1081,7 @@ namespace UdonSharpEditor
                             objectRefs = GetBehaviourComponentOrGameObjectReferences(udonBehaviour);
                         }
                         
-                        foreach (var newObjRef in GetRootPrefabGameObjectRefs((objectRefs != null && objectRefs.Count != 0) ? objectRefs : null))
+                        foreach (GameObject newObjRef in GetRootPrefabGameObjectRefs((objectRefs != null && objectRefs.Count != 0) ? objectRefs : null))
                         {
                             if (!visitedSet.Contains(newObjRef))
                                 newVisitSet.Add(newObjRef);
@@ -1584,9 +1584,9 @@ namespace UdonSharpEditor
 
         private static bool AreUdonSharpScriptsUpdated()
         {
-            var allPrograms = UdonSharpProgramAsset.GetAllUdonSharpPrograms();
+            UdonSharpProgramAsset[] allPrograms = UdonSharpProgramAsset.GetAllUdonSharpPrograms();
 
-            foreach (var programAsset in allPrograms)
+            foreach (UdonSharpProgramAsset programAsset in allPrograms)
             {
                 if (programAsset.ScriptVersion != UdonSharpProgramVersion.CurrentVersion)
                     return false;
@@ -1960,7 +1960,7 @@ namespace UdonSharpEditor
 
                 bool needsUpdate = false;
 
-                foreach (var behaviour in behaviours)
+                foreach (UdonBehaviour behaviour in behaviours)
                 {
                     if (!UdonSharpEditorUtility.IsUdonSharpBehaviour(behaviour))
                         continue;

--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpPrefabDAG.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpPrefabDAG.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UdonSharpEditor
+{
+    /// <summary>
+    /// Contains a set of Directed Acyclic Graphs that may or may not be connected at any point. The set of DAGs is rooted on prefabs that contain no nested prefabs and are not variants.
+    /// If a prefab nests another prefab, the prefab is considered a 'child' of the prefab that it is nesting. Because the parents must be visited and resolved before the children.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    internal class UdonSharpPrefabDAG : IEnumerable<GameObject>
+    {
+        private class Vertex
+        {
+            public GameObject Prefab;
+            public List<Vertex> Children = new List<Vertex>();
+            public List<Vertex> Parents = new List<Vertex>();
+        }
+
+        private List<Vertex> _vertices = new List<Vertex>();
+        private Dictionary<GameObject, Vertex> _vertexLookup = new Dictionary<GameObject, Vertex>();
+        private List<GameObject> _sortedVertices = new List<GameObject>();
+
+        public UdonSharpPrefabDAG(IEnumerable<GameObject> allPrefabRoots)
+        {
+            foreach (GameObject prefabRoot in allPrefabRoots)
+            {
+                Vertex vert = new Vertex() { Prefab = prefabRoot };
+                _vertices.Add(vert);
+                _vertexLookup.Add(prefabRoot, vert);
+            }
+
+            foreach (Vertex vertex in _vertices)
+            {
+                if (PrefabUtility.IsPartOfVariantPrefab(vertex.Prefab))
+                {
+                    Vertex parent = _vertexLookup[PrefabUtility.GetCorrespondingObjectFromSource(vertex.Prefab)];
+                    Debug.Assert(parent != vertex);
+                    
+                    vertex.Parents.Add(parent);
+                    parent.Children.Add(vertex);
+                }
+
+                foreach (GameObject child in vertex.Prefab.GetComponentsInChildren<Transform>(true).Select(e => e.gameObject))
+                {
+                    if (child == vertex.Prefab)
+                    {
+                        continue;
+                    }
+
+                    if (PrefabUtility.IsAnyPrefabInstanceRoot(child))
+                    {
+                        GameObject parentPrefab = PrefabUtility.GetCorrespondingObjectFromSource(child);
+                        
+                        Debug.Assert(parentPrefab);
+                        Debug.Assert(parentPrefab != child);
+
+                        Vertex parent = _vertexLookup[parentPrefab];
+                        
+                        vertex.Parents.Add(parent);
+                        parent.Children.Add(vertex);
+                    }
+                }
+            }
+            
+            // Do sorting
+            HashSet<Vertex> visitedVertices = new HashSet<Vertex>();
+
+            // Orphaned nodes with no parents or children go first
+            foreach (Vertex vertex in _vertices)
+            {
+                if (vertex.Children.Count == 0 && vertex.Parents.Count == 0)
+                {
+                    visitedVertices.Add(vertex);
+                    _sortedVertices.Add(vertex.Prefab);
+                }
+            }
+
+            Queue<Vertex> openSet = new Queue<Vertex>();
+
+            // Find root nodes with no parents
+            foreach (Vertex vertex in _vertices)
+            {
+                if (!visitedVertices.Contains(vertex) && vertex.Parents.Count == 0)
+                {
+                    openSet.Enqueue(vertex);
+                }
+            }
+
+            while (openSet.Count > 0)
+            {
+                Vertex vertex = openSet.Dequeue();
+
+                if (visitedVertices.Contains(vertex))
+                {
+                    continue;
+                }
+
+                if (vertex.Parents.Count > 0)
+                {
+                    bool neededParentVisit = false;
+
+                    foreach (Vertex vertexParent in vertex.Parents)
+                    {
+                        if (!visitedVertices.Contains(vertexParent))
+                        {
+                            neededParentVisit = true;
+                            openSet.Enqueue(vertexParent);
+                        }
+                    }
+
+                    if (neededParentVisit)
+                    {
+                        // Re-queue to visit after we have traversed the node's parents
+                        openSet.Enqueue(vertex);
+                        continue;
+                    }
+                }
+
+                visitedVertices.Add(vertex);
+                _sortedVertices.Add(vertex.Prefab);
+
+                foreach (Vertex vertexChild in vertex.Children)
+                {
+                    openSet.Enqueue(vertexChild);
+                }
+            }
+
+            // Sanity check
+            foreach (Vertex vertex in _vertices)
+            {
+                if (!visitedVertices.Contains(vertex))
+                {
+                    throw new Exception($"Invalid DAG state: node '{vertex.Prefab}' was not visited.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Iterates the DAG in topological order where all parents are visited before their children.
+        /// Will iterate orphan nodes that don't have any parents or children first.
+        /// </summary>
+        public IEnumerator<GameObject> GetEnumerator()
+        {
+            return _sortedVertices.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpPrefabDAG.cs.meta
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpPrefabDAG.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 667b852e57f544c593e121b6400c7643
+timeCreated: 1668580475


### PR DESCRIPTION
Adds handling for upgrading nested prefabs from U# 0.x. 

Does this by first building a directed acyclic graph out of any prefabs with UdonSharpBehaviours. The DAG is organized where 'parent' nodes are prefabs that do not contain any nested prefabs, but may be contained in other prefabs. The children nodes from those parents are then prefabs that nest the parent prefabs along with any prefab variants of the parents. This allows a topological ordering that visits prefabs in an order that will always visit prefabs that other prefabs nest before the nesting prefabs are visited.

After we have a topological ordering of prefabs, we visit it in reverse order and apply prefab modifications to the serialized string and object reference array fields on all UdonBehaviours that are U# behaviours. This ensures that the following upgrade passes do not get partial/leaked data from their 'parent' prefabs already being upgraded.

We next pass over the topological order and do phase 1 of upgrading prefabs which adds the U# behaviour proxies. This is currently different from the old process in that we now open the prefabs in a temp scene to edit them via `PrefabUtility.LoadPrefabContents()` because I haven't verified that it's safe to modify nested prefabs using the old method where we just load them directly. 

Then we do the same phase 2 upgrade where we pass over all the prefabs again, but now it's in topological order, and we copy the data from the UdonBehaviours to their UdonSharpBehaviour proxies. Finally, calling ApplyProperyModifications on the proxy gets Unity to find the deltas from the 'child' prefabs so you get the proper deltas on the U# proxy.