### PR TITLE
Fixes errors pointing at LogError instead of project asset

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/UdonSharpCompilerV1.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/UdonSharpCompilerV1.cs
@@ -282,7 +282,7 @@ namespace UdonSharp.Compiler
             {
                 if (udonSharpProgram.sourceCsScript == null)
                 {
-                    UdonSharpUtils.LogError($"Source C# script on {udonSharpProgram} is null", udonSharpProgram);
+                    UdonSharpUtils.LogError($"Source C# script on {udonSharpProgram} is null. Add the source C# script, or delete {udonSharpProgram}.", udonSharpProgram);
                     hasError = true;
                     continue;
                 }
@@ -291,7 +291,7 @@ namespace UdonSharp.Compiler
                 
                 if (string.IsNullOrEmpty(assetPath))
                 {
-                    UdonSharpUtils.LogError($"Source C# script on {udonSharpProgram} is null", udonSharpProgram);
+                    UdonSharpUtils.LogError($"Source C# script on {udonSharpProgram} is null. Add the source C# script, or delete {udonSharpProgram}.", udonSharpProgram);
                     hasError = true;
                     continue;
                 }

--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpUtils.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpUtils.cs
@@ -329,6 +329,13 @@ namespace UdonSharp
             Debug.LogError($"[<color=#FF00FF>UdonSharp</color>] {message}", context);
         }
 
+        public static void LogError(object message, UdonSharpProgramAsset context)
+        {
+            var asset = AssetDatabase.FindAssets($"t:{nameof(UdonSharpProgramAsset)} {context.name}");
+            if (asset == null || asset[0] == null) LogError(message, context);
+            else Debug.LogError($"[<color=#FF00FF>UdonSharp</color>] {message}", AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(AssetDatabase.GUIDToAssetPath(asset[0])));
+        }
+
         private static readonly MethodInfo _displayProgressBar = typeof(Editor).Assembly.GetTypes().FirstOrDefault(e => e.Name == "AsyncProgressBar")?.GetMethod("Display");
         private static readonly MethodInfo _clearProgressBar = typeof(Editor).Assembly.GetTypes().FirstOrDefault(e => e.Name == "AsyncProgressBar")?.GetMethod("Clear");
         


### PR DESCRIPTION
@MerlinVR should weigh in before I proceed further.

This fix makes it easier to find U# program assets without a source C# asset. Clicking the error takes the user to the asset, instead of `UdonSharpUtils.cs`'s `LogError`.

