### PR TITLE
Fix not being able to create U# Scripts in the packages folder

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpBehaviourEditor.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpBehaviourEditor.cs
@@ -96,7 +96,7 @@ namespace UdonSharpEditor
 
             folderPath = folderPath.Replace('\\', '/');
             
-            string chosenFilePath = EditorUtility.SaveFilePanelInProject("Save UdonSharp File", "", "cs", "Save UdonSharp file", folderPath);
+            string chosenFilePath = EditorUtility.SaveFilePanel("Save UdonSharp File", folderPath, "", "cs");
 
             if (chosenFilePath.Length > 0)
             {

--- a/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpGUI.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpGUI.cs
@@ -439,7 +439,7 @@ namespace UdonSharpEditor
             {
                 string thisPath = AssetDatabase.GetAssetPath(programAsset);
                 string fileName = Path.GetFileNameWithoutExtension(thisPath).Replace(" Udon C# Program Asset", "").Replace(" ", "").Replace("#", "Sharp");
-                string chosenFilePath = EditorUtility.SaveFilePanelInProject("Save UdonSharp File", fileName, "cs", "Save UdonSharp file", Path.GetDirectoryName(thisPath));
+                string chosenFilePath = EditorUtility.SaveFilePanel("Save UdonSharp File", Path.GetDirectoryName(thisPath), fileName, "cs");
 
                 if (chosenFilePath.Length > 0)
                 {

--- a/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpSettings.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Editors/UdonSharpSettings.cs
@@ -131,7 +131,13 @@ public class <TemplateClassName> : UdonSharpBehaviour
         {
             string fileName = SanitizeName(Path.GetFileNameWithoutExtension(file));
 
-            string filePath = Path.GetDirectoryName(file);
+            string filePath = Path.GetDirectoryName(file).Replace('\\', '/');
+
+            string projectRoot = Path.GetDirectoryName( Application.dataPath ).Replace('\\', '/');
+
+            //make sure the path is relative to the project root
+            if (filePath.StartsWith(projectRoot))
+                filePath = filePath.Substring(projectRoot.Length + 1); //add 1 to remove trailing slash
 
             return $"{filePath}/{fileName}{Path.GetExtension(file)}";
         }


### PR DESCRIPTION
This fixes the issue of not being able to directly create new U# scripts in a package folder as you are working on it