### PR TITLE
numerical enum comparison

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Binder/Symbols/ImportedUdonSharpTypeSymbol.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Binder/Symbols/ImportedUdonSharpTypeSymbol.cs
@@ -61,10 +61,16 @@ namespace UdonSharp.Compiler.Symbols
                 TypeSymbol parameterType = context.GetTypeSymbol(methodSymbol.Parameters[0].Type);
 
                 BuiltinOperatorType operatorType;
-                if (methodSymbol.Name == "op_Equality")
-                    operatorType = BuiltinOperatorType.Equality;
-                else
-                    operatorType = BuiltinOperatorType.Inequality;
+                switch (methodSymbol.Name)
+                {
+                    case "op_Equality": operatorType = BuiltinOperatorType.Equality; break;
+                    case "op_Inequality": operatorType = BuiltinOperatorType.Inequality; break;
+                    case "op_GreaterThan": operatorType = BuiltinOperatorType.GreaterThan; break;
+                    case "op_LessThan": operatorType = BuiltinOperatorType.LessThan; break;
+                    case "op_GreaterThanOrEqual": operatorType = BuiltinOperatorType.GreaterThanOrEqual; break;
+                    case "op_LessThanOrEqual": operatorType = BuiltinOperatorType.LessThanOrEqual; break;
+                    default: throw new NotSupportedException($"Operator {methodSymbol.Name} for enum is not currently supported by U#", methodSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()?.GetLocation());
+                }
                 
                 return new ExternSynthesizedOperatorSymbol(operatorType, parameterType.UdonType, context);
             }


### PR DESCRIPTION
Currently, U# doesn't allow us to directly compare enum variable with number like:

EnumHoge fuga = EnumHoge.Fuga;
var comp = fuga >= 3;

When EnumHoge.Fuga is 1, our expected result is comp=false, but the current implementation transcodes like: var comp = fuga != 3;
which leads comp to be TRUE.

Note that this phenomenon doesn't occur when you write enum in the comparison code like: var comp = HogeEnum.Fuga >= 3;
because HogeEnum.Fuga is transcoded to const -1, which makes the >= operation int>=int.

This change let you appropreately convert fuga >= 3 as it is.