### PR TITLE
Fix strip unary plus operator

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/Compiler/Binder/BinderSyntaxVisitor.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/Compiler/Binder/BinderSyntaxVisitor.cs
@@ -42,7 +42,7 @@ namespace UdonSharp.Compiler.Binder
 
             // Strip unary plus operator
             if (node.Kind() == SyntaxKind.UnaryPlusExpression)
-                return Visit((node as PrefixUnaryExpressionSyntax)?.Operand);
+                return VisitExpression((node as PrefixUnaryExpressionSyntax)?.Operand);
             
             Symbol nodeSymbol = GetSymbol(node);
             if (nodeSymbol is TypeSymbol)

--- a/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
+++ b/Packages/com.vrchat.UdonSharp/Tests~/TestScripts/Core/ArithmeticTest.cs
@@ -34,6 +34,7 @@ namespace UdonSharp.Tests
             UdonBehaviourFieldCompoundAssignment();
             NullEquals();
             CastCharToFloat();
+            UnaryPlus();
         }
 
         void IntBinaryOps()
@@ -480,6 +481,12 @@ namespace UdonSharp.Tests
             tester.TestAssertion("Cast char to float", c == 97f);
             tester.TestAssertion("Cast char to double", c == 97.0);
             tester.TestAssertion("Cast char to decimal", c == 97m);
+        }
+
+        void UnaryPlus()
+        {
+            int n = 1;
+            tester.TestAssertion("Strip unary plus operator", +n == 1);
         }
     }
 }


### PR DESCRIPTION
Fix an issue that caused a compilation error when a variable name was preceded by a unary plus operator.