### PR TITLE
Replaced OnSpawn() with OnEnable() in VRChat-API.md

### DIFF
--- a/Tools/Docusaurus/docs/VRChat-API.md
+++ b/Tools/Docusaurus/docs/VRChat-API.md
@@ -293,7 +293,7 @@ VRC Object Pool provides a lightweight method of managing an array of game objec
 
 Objects are made active by the pool via the TryToSpawn node, which will return the object that was made active, or a null object if none are available. Objects may be returned to the pool by the pool's owner, and automatically disabled, via the Return node.
 
-When objects are enabled by the pool the OnSpawn event is fired, which an udon behaviour on the object may listen for.
+When objects are enabled by the pool the OnEnable event is fired, which an udon behaviour on the object may listen for.
 
 Late joiners will have the objects automatically made active or inactive where appropriate.
 


### PR DESCRIPTION
Replaced the now deprecated OnSpawn event with the OnEnable event, since OnSpawn no longer works in SDK3 as mentioned here: https://creators.vrchat.com/worlds/udon/graph/event-nodes/#onspawn
This change was described by Phasedragon on the UdonSharp Discord a while ago: "OnSpawn is a weird SDK2 thing that was briefly reused during the initial beta of vrc object pool, but was removed in favor of just using OnEnable" - Phasedragon, VRChat developer (source: https://discord.com/channels/652715801714884620/675459259441610807/1167974238955774023)