### PR TITLE
Updated VRChat-API.md, Removed EventTiming.FixedUpdate because it does not exist

### DIFF
--- a/Tools/Docusaurus/docs/VRChat-API.md
+++ b/Tools/Docusaurus/docs/VRChat-API.md
@@ -402,9 +402,8 @@ A component used to create portals to other rooms.
 
 | Name | Summary |
 | --- | --- |
-| Update | The event is fired in during the `Update()` event. |
-| LateUpdate | The event is fired in during the `LateUpdate()` event. |
-| FixedUpdate | The event is fired in during the `FixedUpdate()` event. |
+| Update | The event is fired during the `Update()` event. |
+| LateUpdate | The event is fired during the `LateUpdate()` event. |
 
 ### Mobility
 `enum VRC.SDKBase.VRCStation.Mobility`


### PR DESCRIPTION
Removed EventTiming.FixedUpdate because it does not exist, even though we have been waiting for over 2 years for it to be added and it would be amazing to have it. See https://feedback.vrchat.com/udon/p/please-add-eventtimingfixedupdate