### PR TITLE
Add AvatarRoot to TrackingDataType documentation

### DIFF
--- a/Tools/Docusaurus/docs/VRChat-API.md
+++ b/Tools/Docusaurus/docs/VRChat-API.md
@@ -440,6 +440,7 @@ A component used to create portals to other rooms.
 | LeftHand | The player's left hand tracking data |
 | RightHand | The player's right hand tracking data |
 | Origin | The player's playspace origin |
+| AvatarRoot | The root transform of the player's avatar |
 
 ### VRCInputMethod
 `enum VRC.SDKBase.VRCInputMethod`


### PR DESCRIPTION
Added the missing AvatarRoot description.
https://creators.vrchat.com/worlds/udon/players/player-positions#gettrackingdata