### PR TITLE
fix: RuntimeLogWatcher path on Linux

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
@@ -23,7 +23,7 @@ namespace UdonSharpEditor
 
         private static Queue<string> _debugOutputQueue = new Queue<string>();
         private static Dictionary<long, (string, UdonSharpProgramAsset)> _scriptLookup;
-
+        
         // Log watcher vars
         private static FileSystemWatcher _logDirectoryWatcher;
         private static object _logModifiedLock = new object();
@@ -44,12 +44,12 @@ namespace UdonSharpEditor
         }
 
         private static bool _didMissingDataError;
-
+        
         private static bool InitializeScriptLookup()
         {
             if (EditorApplication.isCompiling || EditorApplication.isUpdating)
                 return false;
-
+            
             if (_logDirectoryWatcher == null && ShouldListenForVRC())
             {
                 AssemblyReloadEvents.beforeAssemblyReload += CleanupLogWatcher;
@@ -57,7 +57,7 @@ namespace UdonSharpEditor
                 // Now setup the filesystem watcher
                 string VRCDataPath = null;
 
-#if UNITY_EDITOR_LINUX
+                #if UNITY_EDITOR_LINUX
                 string vrchatAppId = "438100";
                 string steamConfigPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/.steam/steam/steamapps/libraryfolders.vdf";
                 string steamappsVrchatPath = $"steamapps/compatdata/{vrchatAppId}/pfx/drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat/";
@@ -96,10 +96,10 @@ namespace UdonSharpEditor
                     }
                 }
 
-#else // UNITY_EDITOR_WIN || UNITY_EDITOR_MAC
+                #else // UNITY_EDITOR_WIN || UNITY_EDITOR_MAC
                 string[] splitPath = Application.persistentDataPath.Split('/', '\\');
-                VRCDataPath = string.Join("\\", splitPath.Take(splitPath.Length - 2)) + "\\VRChat\\VRChat";
-#endif
+                string VRCDataPath = string.Join("\\", splitPath.Take(splitPath.Length - 2)) + "\\VRChat\\VRChat";
+                #endif				
 
                 if (Directory.Exists(VRCDataPath))
                 {
@@ -200,9 +200,9 @@ namespace UdonSharpEditor
             if (_logDirectoryWatcher != null)
                 _logDirectoryWatcher.EnableRaisingEvents = shouldListenForVRC;
 
-            if (!shouldListenForVRC)
+            if (!shouldListenForVRC) 
                 return;
-
+            
             if (_lineMatch == null)
                 _lineMatch = new Regex(MATCH_STR, RegexOptions.Compiled);
 
@@ -229,7 +229,7 @@ namespace UdonSharpEditor
                             FileInfo fileInfo = new FileInfo(logPath);
 
                             string newLogContent;
-
+                            
                             using (FileStream stream = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                             {
                                 using (StreamReader reader = new StreamReader(stream))
@@ -293,9 +293,9 @@ namespace UdonSharpEditor
                 }
             }
 
-            if (modifiedFilesAndContents == null)
+            if (modifiedFilesAndContents == null) 
                 return;
-
+            
             foreach ((string filePath, string contents) in modifiedFilesAndContents)
             {
                 LogFileState state = _logFileStates[filePath];
@@ -353,7 +353,7 @@ namespace UdonSharpEditor
                     int currentErrorIndex = contents.IndexOf(errorMatchStr, StringComparison.Ordinal);
                     while (currentErrorIndex != -1)
                     {
-                        HandleLogError(contents.Substring(currentErrorIndex, contents.Length - currentErrorIndex), $"VRChat client runtime Udon exception detected!", $"{state.playerName ?? "Unknown"}");
+                        HandleLogError(contents.Substring(currentErrorIndex, contents.Length - currentErrorIndex), $"VRChat client runtime Udon exception detected!", $"{ state.playerName ?? "Unknown"}");
 
                         currentErrorIndex = contents.IndexOf(errorMatchStr, currentErrorIndex + errorMatchStr.Length, StringComparison.Ordinal);
                     }
@@ -480,7 +480,7 @@ namespace UdonSharpEditor
                 Match programCounterMatch = Regex.Match(errorStr, @"Program Counter was at: (?<counter>\d+)");
 
                 programCounter = int.Parse(programCounterMatch.Groups["counter"].Value);
-
+                
                 Match programTypeMatch = Regex.Match(errorStr, @"Heap Dump:[\n\r\s]+[\d]x[\d]+: (?<programID>[-]?[\d]+)[\n\r\s]+[\d]x[\d]+: (?<programName>[\w]+)");
 
                 programID = long.Parse(programTypeMatch.Groups["programID"].Value);

--- a/Tools/Docusaurus/docs/VRChat-API.md
+++ b/Tools/Docusaurus/docs/VRChat-API.md
@@ -87,7 +87,7 @@
 #### Properties
 | Static | Type | Name | Summary |
 | :---: | --- | --- | --- |
-| ✔️ | bool | isMaster | Returns if the local player is the instance master |
+| ✔️ | bool | IsMaster | Returns if the local player is the instance master |
 | ✔️ | [VRCPlayerApi](#vrcplayerapi) | LocalPlayer | Returns the current player |
 | ✔️ | bool | IsNetworkSettled | Returns true if the network is ready |
 


### PR DESCRIPTION
Previously, VRChat path was hardcoded to 1 specific location. While steam library can be on another path, Listen for client exceptions should now correctly find the VRChat log path on Linux.