### PR TITLE
fix: Reloading Domain extremely long in some cases

### DIFF
--- a/Packages/com.vrchat.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
+++ b/Packages/com.vrchat.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
@@ -148,7 +148,10 @@ namespace UdonSharpEditor
         private static void OnEditorUpdate()
         {
             if (!InitializeScriptLookup())
+            {
+                CleanupLogWatcher();
                 return;
+            }
 
             while (_debugOutputQueue.Count > 0)
             {


### PR DESCRIPTION
When VRChat log path isn't found, Reloading Domain time increases infinitely. I've encountered this issue on Linux and Windows, but in anycase we don't want the watchlog running for nothing if VRChat log path isn't found.

Edit: this is also fixing a lot of editor lag/stutter after a while

Linked canny: https://feedback.vrchat.com/sdk-bug-reports/p/udonsharp-watchlog-causing-extreme-long-reloading-domain-time-and-editor-stutter
